### PR TITLE
CONSF-31 adding travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 0.12.1
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
   - 0.12.1
-script:
-  - npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "jspm install && python -m SimpleHTTPServer",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Tests aren't set up yet, so exit\" && exit 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds Travis CI for running unit tests. There's no tests set up yet, so for now travis will just pass. Note that `npm test` is the default command to run tests so we don't have to include it here. 
